### PR TITLE
Fixed passing of config options

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -678,13 +678,13 @@ class DebianInfo:
             # Allow distutils commands to override config files (this lets
             # command line options beat file options).
             for longopt, shortopt, desc in stdeb_cfg_options:
-                name = longopt[:-1]
-                name = name.replace('-','_')
+                opt_name = longopt[:-1]
+                name = opt_name.replace('-','_')
                 value = getattr( sdist_dsc_command, name )
                 if value is not None:
                     if not cfg.has_section(module_name):
                         cfg.add_section(module_name)
-                    cfg.set( module_name, name, value )
+                    cfg.set( module_name, opt_name, value )
 
         self.stdeb_version = __stdeb_version__
         self.module_name = module_name


### PR DESCRIPTION
I noticed that it is not possible to pass some config options from command line.
All config options with dash "-" were ignored when passed from the command line.
For example, --dpkg-shlibdeps-params=-v was ignored.

The commit fixes the passing of the correct names to the ConfigParser.

Thanks for the tool.
