### PR TITLE
Fix/docs pycentral 548392

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -441,13 +441,6 @@ To pass these commands to sdist_dsc when calling bdist_deb, do this::
   --remove-expanded-source-dir (-r)    remove the expanded source directory
   --ignore-install-requires (-i)       ignore the requirements from
                                        requires.txt in the egg-info directory
-  --pycentral-backwards-compatibility  If True, enable migration from old
-                                       stdeb that used pycentral.
-                                       (Default=False).
-  --workaround-548392                  If True, limit binary package to single
-                                       Python version, working around Debian
-                                       bug 548392 of debhelper.
-                                       (Default=False).
   --force-buildsystem                  If True (the default), set 'DH_OPTIONS=
                                        --buildsystem=python_distutils'
   --no-backwards-compatibility         This option has no effect, is here for


### PR DESCRIPTION
The options `--pycentral-backwards-compatibility` and `--workaround-548392` were removed with commit 7f2a1d74edd8a7f21534b5992ad4fa89a38fd494. Update the docs to reflect this change.
