### PR TITLE
Ignore .egg-info files when building debian packages.

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1129,6 +1129,10 @@ def build_dsc(debinfo,
     fd.write('1.0\n')
     fd.close()
 
+    fd = open( os.path.join(debian_dir,'source','options'), mode='w')
+    fd.write('extended-diff-ignore="\.egg-info"')
+    fd.close()
+
     if debian_dir_only:
         return
 


### PR DESCRIPTION
I was having a problem where py2dsc was dying because
it was trying to generate a diff that was including the
.egg-info directory setup.py was creating.

It turns out Arnaud Fontaine arnau@debian.org had the same problem
and suggested a fix -- to add extended-diff-ignore to debian/source/options

Fixes deb#657611
