### PR TITLE
Provide --guess-depends-package-name=True option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 setup(name='stdeb',
       # Keep version in sync with stdeb/__init__.py, Install section
       # of README.rst, and USER_AGENT in scripts/pypi-install.
-      version='0.6.0.1',
+      version='0.6.0.2',
       author='Andrew Straw',
       author_email='strawman@astraw.com',
       description='Python to Debian source package conversion utility',

--- a/stdeb/__init__.py
+++ b/stdeb/__init__.py
@@ -1,5 +1,5 @@
 import logging
-__version__ = '0.6.0' # keep in sync with ../setup.py
+__version__ = '0.6.0.2' # keep in sync with ../setup.py
 
 log = logging.getLogger('stdeb')
 log.setLevel(logging.INFO)

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -24,6 +24,7 @@ class common_debian_package_command(Command):
         self.no_backwards_compatibility = None
         self.guess_conflicts_provides_replaces = None
         self.guess_depends_package_name = None
+        self.suppress_packaging_version = None
 
         # deprecated options
         self.default_distribution = None
@@ -206,6 +207,7 @@ class common_debian_package_command(Command):
             use_setuptools = use_setuptools,
             guess_conflicts_provides_replaces=self.guess_conflicts_provides_replaces,
             guess_depends_package_name=self.guess_depends_package_name,
+            suppress_packaging_version=self.suppress_packaging_version,
             sdist_dsc_command = self,
         )
         return debinfo


### PR DESCRIPTION
This pull request provides option --guess-depends-package-name=True to guess depends package name in cases it cannot be found in repository. It useful when autobuilding deb-package from Python source distributions. It prevents installing generated deb-packages with wrong dependencies.
