### PR TITLE
Fix a few things that weren't Python 3 compatible

### DIFF
--- a/scripts/py2dsc
+++ b/scripts/py2dsc
@@ -99,18 +99,18 @@ def runit():
     abs_dist_dir = os.path.abspath(final_dist_dir)
 
     extra_args = []
-    for long in parser.long_opts:
-        if long in ['dist-dir=','patch-file=']:
+    for lopt in parser.long_opts:
+        if lopt in ['dist-dir=','patch-file=']:
             continue # dealt with by this invocation
-        attr = parser.get_attr_name(long).rstrip('=')
+        attr = parser.get_attr_name(lopt).rstrip('=')
         if hasattr(optobj,attr):
             val = getattr(optobj,attr)
             if attr=='extra_cfg_file':
                 val = os.path.abspath(val)
-            if long in bool_opts or long.replace('-', '_') in bool_opts:
-                extra_args.append('--%s' % long)
+            if lopt in bool_opts or lopt.replace('-', '_') in bool_opts:
+                extra_args.append('--%s' % lopt)
             else:
-                extra_args.append('--'+long+str(val))
+                extra_args.append('--'+lopt+str(val))
 
     if patch_already_applied == 1:
         extra_args.append('--patch-already-applied')

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -24,9 +24,8 @@ DH_IDEAL_VERS = '7.4.3' # fixes Debian bug 548392
 
 PYTHON_ALL_MIN_VERS = '2.6.6-3'
 
-import exceptions
-class CalledProcessError(exceptions.Exception): pass
-class CantSatisfyRequirement(exceptions.Exception): pass
+class CalledProcessError(Exception): pass
+class CantSatisfyRequirement(Exception): pass
 
 def check_call(*popenargs, **kwargs):
     retcode = subprocess.call(*popenargs, **kwargs)


### PR DESCRIPTION
Installing on Python 3 requires a 2to3 pass as well,
these are just extra fixes that need to be run before
2to3.
