### PR TITLE
remove sudo from scripts

### DIFF
--- a/scripts/pypi-install
+++ b/scripts/pypi-install
@@ -85,6 +85,10 @@ def get_source_tarball(package_name,verbose=0):
     return fname
 
 def main():
+    if os.geteuid() != 0:
+        myprint('%s must be run as root'%os.path.basename(sys.argv[0]),fd=sys.stderr)
+        sys.exit(1)
+
     usage = '%prog PACKAGE_NAME [options]'
     parser = OptionParser(usage)
     parser.add_option('--verbose', type='int',
@@ -128,7 +132,7 @@ def main():
         subprocess.check_call(cmd, shell=True)
 
         os.chdir( 'deb_dist' )
-        cmd = 'sudo dpkg -i *.deb'
+        cmd = 'dpkg -i *.deb'
         if options.verbose >= 2:
             myprint('executing: %s'%cmd)
         subprocess.check_call(cmd, shell=True)

--- a/test-pypi-install.sh
+++ b/test-pypi-install.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 set -e
 
+if [ "$UID" -ne "0" ]; then
+  echo "$0 must be run as root"
+  exit 1
+fi
+
 # Package with source tarball on PyPI:
 pypi-install pyflakes --verbose=2
-sudo dpkg --purge python-pyflakes
+dpkg --purge python-pyflakes
 
 # Package with no source tarball on PyPI: (v 0.6.2, 2009-12-30)
 pypi-install posix_ipc --verbose=2
-sudo dpkg --purge python-posixipc
+dpkg --purge python-posixipc
 
 echo "skipping known failure tests"
 exit 0
@@ -21,5 +26,5 @@ pypi-install zope.site --verbose=2
 #   the Debian/Ubuntu original "pyro" package is already
 #   installed. This should use apt-file to find that binary package is
 #   "pyro".)
-sudo apt-get install pyro # get upstream version
+apt-get install pyro # get upstream version
 pypi-install Pyro --verbose=2


### PR DESCRIPTION
Instead, ensure that scripts are run as root.

It's usually a bad idea to use "sudo" within a script because suddenly the script is
opaquely running as different users. Instead, the script should either require the user
to be root (or within sudo); or handle the situation where the user is not root by
e.g. not installing the debian package.

The usage of sudo also prevents automated installs in most cases.

This flaw breaks the package for me. My sudoers configuration prevents root from
running sudo - so the final step always fails if you're already root (or using sudo).

caveat: I have not done careful testing that something might become broken after running
the command as root. i.e. if the original author intended most things to be run as a
standard user, it may be useful to double-check that nothing gets trampled.
