### PR TITLE
Replace any newlines or repeated whitespace in the description

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -773,7 +773,7 @@ class DebianInfo:
 
         self.debian_section = parse_val(cfg,module_name,'Section')
 
-        self.description = description
+        self.description = re.sub('\s+', ' ', description).strip()
         if long_description != 'UNKNOWN':
             ld2=[]
             for line in long_description.split('\n'):


### PR DESCRIPTION
This cleans up the "description" field, which for some packages (eg, django-statsd) contains newlines.  I'm pretty sure these are invalid description fields to put in setup.py, but since they exist it is good to handle them.
