### PR TITLE
Adjust PyPI URL to new home of PyPI

### DIFF
--- a/stdeb/downloader.py
+++ b/stdeb/downloader.py
@@ -12,7 +12,7 @@ def myprint(mystr,fd=None):
 
 USER_AGENT = 'pypi-install/0.6.0+git ( https://github.com/astraw/stdeb )'
 
-def find_tar_gz(package_name, pypi_url = 'https://python.org/pypi',verbose=0):
+def find_tar_gz(package_name, pypi_url = 'https://pypi.python.org/pypi',verbose=0):
     transport = xmlrpclib.Transport()
     transport.user_agent = USER_AGENT
     pypi = xmlrpclib.ServerProxy(pypi_url, transport=transport)


### PR DESCRIPTION
Without this, pypi-install is broken.

This patch is important, as without it, the find_tar_gz() function
crashes with:

  File "/usr/lib/python2.7/xmlrpclib.py", line 1312, in single_request
    response.msg,
xmlrpclib.ProtocolError: <ProtocolError for python.org/pypi: 301 Moved Permanently>

This addresses the problem by using the canonical URL of PyPI.

I hereby license this under the same terms of distribution as stdeb itself.
