### PR TITLE
fix py 2.6 compatibilty

### DIFF
--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -20,11 +20,11 @@ class common_debian_package_command(Command):
         self.debian_version = None
         self.no_backwards_compatibility = None
         self.guess_conflicts_provides_replaces = None
-        if sys.version_info.major==2:
+        if sys.version_info[0]==2:
             self.with_python2 = 'True'
             self.with_python3 = 'False'
         else:
-            assert sys.version_info.major==3
+            assert sys.version_info[0]==3
             self.with_python2 = 'False'
             self.with_python3 = 'True'
         self.no_python2_scripts = 'False'

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -45,11 +45,11 @@ def check_call(*popenargs, **kwargs):
         return
     raise CalledProcessError(retcode)
 
-if sys.version_info.major==2:
+if sys.version_info[0]==2:
     help_str_py2='If True, build package for python 2. (Default=True).'
     help_str_py3='If True, build package for python 3. (Default=False).'
 else:
-    assert sys.version_info.major==3
+    assert sys.version_info[0]==3
     help_str_py2='If True, build package for python 2. (Default=False).'
     help_str_py3='If True, build package for python 3. (Default=True).'
 

--- a/test_data/py2_only_pkg/setup.py
+++ b/test_data/py2_only_pkg/setup.py
@@ -7,7 +7,7 @@ import sys
 class my_build(build):
     """ensure (at runtime) we are running python 2"""
     def __init__(self,*args,**kwargs):
-        assert sys.version_info.major==2
+        assert sys.version_info[0]==2
         build.__init__(self,*args,**kwargs)
 
 setup(name='py2_only_pkg',

--- a/test_data/py3_only_pkg/setup.py
+++ b/test_data/py3_only_pkg/setup.py
@@ -7,7 +7,7 @@ import sys
 class my_build(build):
     """ensure (at runtime) we are running python 3"""
     def __init__(self,*args,**kwargs):
-        assert sys.version_info.major==3
+        assert sys.version_info[0]==3
         build.__init__(self,*args,**kwargs)
 
 setup(name='py3_only_pkg',


### PR DESCRIPTION
Not extensively tested at the moment, but running test.sh works in python 2.6 and sys.version_info[0] does indeed equal 2 on python 2.7.
