### PR TITLE
add --x-python3-version and --force-x-python3-version options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -596,6 +596,7 @@ To pass these commands to sdist_dsc when calling bdist_deb, do this::
   --suggests                           debian/control Suggests:
   --recommends                         debian/control Recommends:
   --xs-python-version                  debian/control XS-Python-Version:
+  --x-python3-version                  debian/control X-Python3-Version:
   --dpkg-shlibdeps-params              parameters passed to dpkg-shlibdeps
   --conflicts                          debian/control Conflicts:
   --provides                           debian/control Provides:
@@ -663,6 +664,7 @@ All available options:
   Suggests                             debian/control Suggests:
   Recommends                           debian/control Recommends:
   XS-Python-Version                    debian/control XS-Python-Version:
+  X-Python3-Version                    debian/control X-Python3-Version:
   Dpkg-Shlibdeps-Params                parameters passed to dpkg-shlibdeps
   Conflicts                            debian/control Conflicts:
   Provides                             debian/control Provides:

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -29,6 +29,7 @@ class common_debian_package_command(Command):
             self.with_python3 = 'True'
         self.no_python2_scripts = 'False'
         self.no_python3_scripts = 'False'
+        self.force_x_python3_version = False
 
         # deprecated options
         self.default_distribution = None
@@ -215,5 +216,6 @@ class common_debian_package_command(Command):
             with_python3 = self.with_python3,
             no_python2_scripts = self.no_python2_scripts,
             no_python3_scripts = self.no_python3_scripts,
+            force_x_python3_version=self.force_x_python3_version,
         )
         return debinfo

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -143,6 +143,7 @@ stdeb_cfg_options = [
     ('suggests=',None,'debian/control Suggests:'),
     ('recommends=',None,'debian/control Recommends:'),
     ('xs-python-version=',None,'debian/control XS-Python-Version:'),
+    ('x-python3-version=',None,'debian/control X-Python3-Version:'),
     ('dpkg-shlibdeps-params=',None,'parameters passed to dpkg-shlibdeps'),
     ('conflicts=',None,'debian/control Conflicts:'),
     ('provides=',None,'debian/control Provides:'),
@@ -899,6 +900,12 @@ class DebianInfo:
         if len(xs_python_version)!=0:
             self.source_stanza_extras += ('X-Python-Version: '+
                                           ', '.join(xs_python_version)+'\n')
+
+        x_python3_version = parse_vals(cfg,module_name,'X-Python3-Version')
+
+        if len(x_python3_version)!=0:
+            self.source_stanza_extras += ('X-Python3-Version: '+
+                                          ', '.join(x_python3_version)+'\n')
 
         dpkg_shlibdeps_params = parse_val(
             cfg,module_name,'dpkg-shlibdeps-params')


### PR DESCRIPTION
Based on discussion ros/rosdistro#5944

Currently the Python 3 Debian package always has a dependency on the Python 3 version of the system where the packaging is run.

This patch adds support for putting `X-Python3-Version` in the `stdeb.cfg` file. If the new option is present and gets passed into the source block of the Debian control file. Additionally `${python3:Depends}` will be omitted to avoid also adding the explicit dependency on the Python version of the system running the packaging command.

If the new option is not in the `stdeb.cfg` file the behavior is unchanged.