### PR TITLE
Invalid assert breaking upstream version options

### DIFF
--- a/stdeb/command/sdist_dsc.py
+++ b/stdeb/command/sdist_dsc.py
@@ -69,7 +69,6 @@ class sdist_dsc(common_debian_package_command):
         assert len(expanded_base_files)==1
         actual_package_dirname = expanded_base_files[0]
         expected_package_dirname = debinfo.module_name + '-' + debinfo.upstream_version
-        assert actual_package_dirname==expected_package_dirname
         shutil.move( os.path.join( tmpdir, actual_package_dirname ),
                      fullpath_repackaged_dirname)
 


### PR DESCRIPTION
There is an unneeded assert that breaks options such as ``Upstream-Version-Suffix``, by assuming that the directory inside the setuptools-generated source package has the same version number as the DEB being created. This commit removes that assert.