### PR TITLE
Adding dh_virtualenv support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# http://travis-ci.org/#!/astraw/stdeb
+# http://travis-ci.org/#!/jul/stdeb
 language: python
 python:
     - "2.7_with_system_site_packages"

--- a/README.rst
+++ b/README.rst
@@ -536,6 +536,10 @@ To pass these commands to sdist_dsc when calling bdist_deb, do this::
 ====================================== =========================================
   --with-python2                       build Python 2 package (default=True)
   --with-python3                       build Python 3 package (default=False)
+  --with-python-virtualenv             use the current irtualenv python
+                                       and packages the virtualenv into the 
+                                       debian packages (using
+                                       `dh-virtualenv <https://github.com/spotify/dh-virtualenv>`__)
   --no-python2-scripts                 disable installation of Python 2 scripts (default=False)
   --no-python3-scripts                 disable installation of Python 3 scripts (default=False)
   --dist-dir (-d)                      directory to put final built

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,3 +1,4 @@
 [stdeb]
-Depends: apt-file, dpkg-dev, python-pkg-resources, python-requests, dh-virtualenv, dh-virtualenv-build-deps
+Depends: apt-file, dpkg-dev, python-pkg-resources, python-requests
 Depends3: apt-file, dpkg-dev, python3-pkg-resources, python3-requests
+Suggests: dh-virtualenv, dh-virtualenv-build-deps

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,3 +1,3 @@
 [stdeb]
-Depends: apt-file, dpkg-dev, python-pkg-resources, python-requests
+Depends: apt-file, dpkg-dev, python-pkg-resources, python-requests, dh-virtualenv, dh-virtualenv-build-deps
 Depends3: apt-file, dpkg-dev, python3-pkg-resources, python3-requests

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -29,6 +29,7 @@ class common_debian_package_command(Command):
             self.with_python3 = 'True'
         self.no_python2_scripts = 'False'
         self.no_python3_scripts = 'False'
+        self.with_python_virtualenv = 'False'
 
         # deprecated options
         self.default_distribution = None
@@ -61,6 +62,7 @@ class common_debian_package_command(Command):
             self.guess_conflicts_provides_replaces = str_to_bool(
                 self.guess_conflicts_provides_replaces)
 
+        self.with_python_virtualenv = str_to_bool(self.with_python_virtualenv)
         self.with_python2 = str_to_bool(self.with_python2)
         self.with_python3 = str_to_bool(self.with_python3)
         self.no_python2_scripts = str_to_bool(self.no_python2_scripts)
@@ -211,6 +213,7 @@ class common_debian_package_command(Command):
             use_setuptools = use_setuptools,
             guess_conflicts_provides_replaces=self.guess_conflicts_provides_replaces,
             sdist_dsc_command = self,
+            with_python_virtualenv = self.with_python_virtualenv,
             with_python2 = self.with_python2,
             with_python3 = self.with_python3,
             no_python2_scripts = self.no_python2_scripts,


### PR DESCRIPTION
by simply replacing --with python2/3 with python-virtualenv and keeping the py2/3 flags we can use sted to directly packages virtualenv WITH the binary dependencies. 

Highly experimental, works for me (tm).
http://dh-virtualenv.readthedocs.org/en/0.8/usage.html
