### PR TITLE
Provide fallback when hardlink fails.

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -13,12 +13,15 @@ import subprocess
 import tempfile
 import stdeb
 from stdeb import log, __version__ as __stdeb_version__
+from functools import partial
+import distutils.file_util
 
 if hasattr(os,'link'):
-    link_func = os.link
+    link_func = partial(distutils.file_util.copy_file, link='hard',
+                        verbose=False)
 else:
     # matplotlib deletes link from os namespace, expected distutils workaround
-    link_func = shutil.copyfile
+    link_func = partial(distutils.file_util.copy_file, verbose=False)
 
 __all__ = ['DebianInfo','build_dsc','expand_tarball','expand_zip',
            'stdeb_cmdline_opts','stdeb_cmd_bool_opts','recursive_hardlink',


### PR DESCRIPTION
[This is an untested proposal, but should work]

In certain situations, hardlinking won't work even on a platform that
supports it (between two disks, for example, or some filesystems on OSs
that otherwise handle hardlinks). Use code from distutils that handles
this gracefully.

Distutils issue describing the problem and solution:
https://bugs.python.org/issue8876
