### PR TITLE
Use setuptools and its entry_points option to avoid  --command-packag…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 import codecs
 
 with codecs.open('README.rst', encoding='utf-8') as file:
@@ -14,6 +14,8 @@ setup(name='stdeb',
       long_description=long_description,
       license='MIT',
       url='http://github.com/astraw/stdeb',
+      entry_points={'distutils.commands': ["%(cmd)s = stdeb.command.%(cmd)s:%(cmd)s" % {'cmd': x}
+                                           for x in ('bdist_deb', 'debianize', 'install_deb', 'sdist_dsc', )], },
       packages=['stdeb','stdeb.command'],
       scripts=['scripts/py2dsc',
                'scripts/py2dsc-deb',


### PR DESCRIPTION
…es=stdeb.command.

However, this requires setuptools (which was removed in 2009).
I do not know why it has been removed, and if these reasons are valid six years later, so I offer this pull request.
