### PR TITLE
get_date_822 pythonic way. OS X does not have -R option for *date*

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1,7 +1,7 @@
 #
 # This module contains most of the code of stdeb.
 #
-import re, sys, os, shutil, select, time
+import re, sys, os, shutil, select, time, calendar
 import codecs
 try:
     # Python 2.x
@@ -257,7 +257,8 @@ def normstr(s):
 
 def get_date_822():
     """return output of 822-date command"""
-    return time.strftime("%a, %e %b %Y %H:%M:%S %z")
+    t = time.localtime()
+    return time.strftime(calendar.day_abbr[t.tm_wday]+ ", %d " + calendar.month_abbr[t.tm_mon] + " %Y %H:%M:%S %z", t)
 
 def get_version_str(pkg):
     args = ['/usr/bin/dpkg-query','--show',

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1,7 +1,7 @@
 #
 # This module contains most of the code of stdeb.
 #
-import re, sys, os, shutil, select
+import re, sys, os, shutil, select, time
 import codecs
 try:
     # Python 2.x
@@ -257,13 +257,7 @@ def normstr(s):
 
 def get_date_822():
     """return output of 822-date command"""
-    cmd = '/bin/date'
-    if not os.path.exists(cmd):
-        raise ValueError('%s command does not exist.'%cmd)
-    args = [cmd,'-R']
-    result = get_cmd_stdout(args).strip()
-    result = normstr(result)
-    return result
+    return time.strftime("%a, %e %b %Y %H:%M:%S %z")
 
 def get_version_str(pkg):
     args = ['/usr/bin/dpkg-query','--show',

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -246,15 +246,6 @@ def get_cmd_stdout(args):
         raise RuntimeError('returncode %d', returncode)
     return cmd.stdout.read()
 
-def normstr(s):
-    try:
-        # Python 3.x
-        result = str(s,'utf-8')
-    except TypeError:
-        # Python 2.x
-        result = s
-    return result
-
 def get_date_822():
     """return output of 822-date command"""
     t = time.localtime()


### PR DESCRIPTION
**OS X:**

```
date -R
date: illegal option -- R
usage: date [-jnu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
```

**On Linux:**

```
date -R
Mon, 26 Oct 2015 12:28:45 +0000
```

```
python -c 'import time; print time.strftime("%a, %e %b %Y %H:%M:%S %z")'
Mon, 26 Oct 2015 12:38:23 +0000
```
