### PR TITLE
Fix applying patch files under Python 3

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -563,6 +563,7 @@ def apply_patch(patchfile,cwd=None,posix=False,level=0):
         stdin=fd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        universal_newlines=True
         )
     returncode=None
     while returncode is None:


### PR DESCRIPTION
In Python 3, the result from Popen is bytes by default, but stdout expects a str, so pass universal_newlines=True to Popen.