### PR TITLE
Travis needs fakeroot installed not to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - "3.2_with_system_site_packages"
 before_install:
     - sudo apt-get update
-    - sudo apt-get install python-all-dev python3-all-dev debhelper python-setuptools python3-setuptools apt-file python-requests
+    - sudo apt-get install fakeroot python-all-dev python3-all-dev debhelper python-setuptools python3-setuptools apt-file python-requests
     - wget http://debs.strawlab.org/precise/python3-requests_2.3.0-0ads1_all.deb -O python3-requests_2.3.0-0ads1_all.deb
     - sudo dpkg -i python3-requests_2.3.0-0ads1_all.deb
 install:


### PR DESCRIPTION
The two newest pull requests  (#134 and #135 ) are failing in Travis, because `fakeroot` is not installed by default and must be specified in the `.travis.yml` file.