### PR TITLE
Add support for Suite3 option to release into different suites based on python version.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -668,6 +668,7 @@ All available options:
                                        python-<debianized-setup-name>)
   Suite                                suite (e.g. stable, lucid) in changelog
                                        (Default: unstable)
+  Suite3                               suite (e.g. stable, lucid) for python3
   Maintainer                           debian/control Maintainer: (Default:
                                        <setup-maintainer-or-author>)
   Debian-Version                       debian version (Default: 1)

--- a/README.rst
+++ b/README.rst
@@ -669,6 +669,7 @@ All available options:
   Suite                                suite (e.g. stable, lucid) in changelog
                                        (Default: unstable)
   Suite3                               suite (e.g. stable, lucid) for python3
+                                       (Default: uses value of Suite option)
   Maintainer                           debian/control Maintainer: (Default:
                                        <setup-maintainer-or-author>)
   Debian-Version                       debian version (Default: 1)

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1163,9 +1163,9 @@ class DebianInfo:
 
         if with_python3:
             self.control_py3_stanza = CONTROL_PY3_STANZA%self.__dict__
-            if self.distname3:
-                if with_python2:
-                    raise ValueError("Suites are shared between versions. To use Suite3 run --with-python3 true --with-python2 false only.")
+            if self.distname3 and self.distname3 != self.distname:
+                if with_python2 :
+                    raise ValueError("Suites are shared between versions. To use a different value for Suite3 run --with-python3 true --with-python2 false only.")
                 self.changelog_distname = CHANGELOG_PY3_DISTNAME%self.__dict__
         else:
             self.control_py3_stanza = ''

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1155,6 +1155,7 @@ class DebianInfo:
         else:
             self.binary_target_lines = ''
 
+        self.changelog_distname = CHANGELOG_PY2_DISTNAME%self.__dict__
         if with_python2:
             self.control_py2_stanza = CONTROL_PY2_STANZA%self.__dict__
         else:
@@ -1162,6 +1163,10 @@ class DebianInfo:
 
         if with_python3:
             self.control_py3_stanza = CONTROL_PY3_STANZA%self.__dict__
+            if self.distname3:
+                if with_python2:
+                    raise ValueError("Suites are shared between versions. To use Suite3 run --with-python3 true --with-python2 false only.")
+                self.changelog_distname = CHANGELOG_PY3_DISTNAME%self.__dict__
         else:
             self.control_py3_stanza = ''
 
@@ -1443,8 +1448,10 @@ def build_dsc(debinfo,
         dpkg_source('-x',dsc_name,
                     cwd=dist_dir)
 
+CHANGELOG_PY2_DISTNAME = '%(distname)s'
+CHANGELOG_PY3_DISTNAME = '%(distname3)s'
 CHANGELOG_FILE = """\
-%(source)s (%(full_version)s) %(distname)s; urgency=low
+%(source)s (%(full_version)s) %(changelog_distname)s; urgency=low
 
   * source package automatically created by stdeb %(stdeb_version)s
 

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -131,7 +131,7 @@ stdeb_cfg_options = [
     ('suite=',None,
      'suite (e.g. stable, lucid) in changelog (Default: unstable)'),
     ('suite3=',None,
-     'suite3 Suites used when building with python3 only. Will fallback to Suite if omitted.'),
+     'suite3 Suites used when building with python3 only (Default: <same-as-suite>)'),
     ('maintainer=',None,
      'debian/control Maintainer: (Default: <setup-maintainer-or-author>)'),
     ('debian-version=',None,'debian version (Default: 1)'),
@@ -1205,6 +1205,10 @@ class DebianInfo:
                 elif value == '<setup-maintainer-or-author>':
                     assert key=='maintainer'
                     value = guess_maintainer
+                elif value == '<same-as-suite>':
+                    assert key=='suite3'
+                    # Set to empty string so value of suite is used.
+                    value = '' 
                 if key=='suite':
                     if default_distribution is not None:
                         value = default_distribution

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -130,6 +130,8 @@ stdeb_cfg_options = [
      'debian/control Package: (Default: python3-<debianized-setup-name>)'),
     ('suite=',None,
      'suite (e.g. stable, lucid) in changelog (Default: unstable)'),
+    ('suite3=',None,
+     'suite3 Suites used when building with python3 only. Will fallback to Suite if omitted.'),
     ('maintainer=',None,
      'debian/control Maintainer: (Default: <setup-maintainer-or-author>)'),
     ('debian-version=',None,'debian version (Default: 1)'),
@@ -791,6 +793,7 @@ class DebianInfo:
             self.upstream_version,
             self.packaging_version)
         self.distname = parse_val(cfg,module_name,'Suite')
+        self.distname3 = parse_val(cfg,module_name,'Suite3')
         self.maintainer = ', '.join(parse_vals(cfg,module_name,'Maintainer'))
         self.uploaders = parse_vals(cfg,module_name,'Uploaders')
         self.date822 = get_date_822()


### PR DESCRIPTION
This pull request adds a new optional configuration field to stdeb.cfg: `Suite3`.
The Suite3 field contains an alternative distname value which is used when building with python3 only.
If the field is not present, python3 builds will use the Suite value or its default.
If a Suite3 field is present, running stdeb with both python2 and python3 will raise a ValueError since only one distname can be used.

The ROS team is hoping to use this feature to avoid releasing python2 variants of our packages onto newer Ubuntu versions where Python 2 support is not planned. It has been tested locally using this example config https://github.com/nuclearsandwich/bloom/blob/example-suite3/stdeb.cfg
