### PR TITLE
Handle path with spaces in zip tarball

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -489,7 +489,7 @@ def expand_zip(zip_fname,cwd=None):
     )
     contents = []
     for line in res.stdout.readlines()[3:-2]:
-        contents.append(b' '.join(line.split()[3:]))
+        contents.append(line.split(None, 3)[3])
     commonprefix = os.path.commonprefix(contents)
     if not commonprefix:
         extdir = os.path.join(cwd, os.path.basename(zip_fname[:-4]))

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -489,7 +489,7 @@ def expand_zip(zip_fname,cwd=None):
     )
     contents = []
     for line in res.stdout.readlines()[3:-2]:
-        contents.append(line.split()[-1])
+        contents.append(b' '.join(line.split()[3:]))
     commonprefix = os.path.commonprefix(contents)
     if not commonprefix:
         extdir = os.path.join(cwd, os.path.basename(zip_fname[:-4]))

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -489,7 +489,7 @@ def expand_zip(zip_fname,cwd=None):
     )
     contents = []
     for line in res.stdout.readlines()[3:-2]:
-        contents.append(line.split(None, 3)[3])
+        contents.append(line.split(None, 3)[-1])
     commonprefix = os.path.commonprefix(contents)
     if not commonprefix:
         extdir = os.path.join(cwd, os.path.basename(zip_fname[:-4]))


### PR DESCRIPTION
This patch handles correctly filenames with spaces in zip archive.