### PR TITLE
Add an option named ignore-source-changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -604,6 +604,9 @@ To pass these commands to sdist_dsc when calling bdist_deb, do this::
   --remove-expanded-source-dir (-r)    remove the expanded source directory
   --ignore-install-requires (-i)       ignore the requirements from
                                        requires.txt in the egg-info directory
+  --ignore-source-changes              ignore all changes on source when
+                                       building source package (add -i.*
+                                       option to dpkg-source)
   --no-backwards-compatibility         This option has no effect, is here for
                                        backwards compatibility, and may be
                                        removed someday.

--- a/stdeb/command/bdist_deb.py
+++ b/stdeb/command/bdist_deb.py
@@ -11,16 +11,22 @@ class bdist_deb(Command):
     user_options = [
         ('sign-results',None,
          'Use gpg to sign the resulting .dsc and .changes file'),
+        ('ignore-source-changes',None,
+         'Ignore all changes on source when building source package '
+         '(add -i.* option to dpkg-source'),
         ]
     boolean_options = [
         'sign-results',
+        'ignore-source-changes',
         ]
 
     def initialize_options (self):
         self.sign_results = False
+        self.ignore_source_changes = False
 
     def finalize_options (self):
         self.sign_results = bool(self.sign_results)
+        self.ignore_source_changes = bool(self.ignore_source_changes)
 
     def run(self):
         # generate .dsc source pkg
@@ -52,6 +58,9 @@ class bdist_deb(Command):
 
         if not self.sign_results:
             syscmd.append('-uc')
+
+        if self.ignore_source_changes:
+            syscmd.append('-i.*')
 
         util.process_command(syscmd,cwd=target_dirs[0])
 

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -32,6 +32,7 @@ class common_debian_package_command(Command):
         self.force_x_python3_version = False
         self.allow_virtualenv_install_location = False
         self.sign_results = False
+        self.ignore_source_changes = False
 
         # deprecated options
         self.default_distribution = None

--- a/stdeb/command/sdist_dsc.py
+++ b/stdeb/command/sdist_dsc.py
@@ -139,6 +139,7 @@ class sdist_dsc(common_debian_package_command):
                   patch_posix = self.patch_posix,
                   remove_expanded_source_dir=self.remove_expanded_source_dir,
                   sign_dsc=self.sign_results,
+                  ignore_source_changes=self.ignore_source_changes,
                   )
 
         for rmdir in cleanup_dirs:

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -538,7 +538,7 @@ def dpkg_buildpackage(*args,**kwargs):
     if len(kwargs)!=0:
         raise ValueError('only kwarg can be "cwd"')
     "call dpkg-buildpackage [arg1] [...] [argN]"
-    args = ['/usr/bin/dpkg-buildpackage'] + list(args)
+    args = ['/usr/bin/dpkg-buildpackage']+list(args)
     process_command(args, cwd=cwd)
 
 def dpkg_source(b_or_x,arg1,cwd=None):

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -109,6 +109,9 @@ stdeb_cmdline_opts = [
      'Allow installing into /some/random/virtualenv-path'),
     ('sign-results',None,
      'Use gpg to sign the resulting .dsc and .changes file'),
+    ('ignore-source-changes',None,
+     'Ignore all changes on source when building source package (add -i.* '
+     'option to dpkg-source)'),
     ]
 
 # old entries from stdeb.cfg:
@@ -181,6 +184,7 @@ stdeb_cmd_bool_opts = [
     'force-x-python3-version',
     'allow-virtualenv-install-location',
     'sign-results',
+    'ignore-source-changes',
     ]
 
 class NotGiven: pass
@@ -534,7 +538,7 @@ def dpkg_buildpackage(*args,**kwargs):
     if len(kwargs)!=0:
         raise ValueError('only kwarg can be "cwd"')
     "call dpkg-buildpackage [arg1] [...] [argN]"
-    args = ['/usr/bin/dpkg-buildpackage']+list(args)
+    args = ['/usr/bin/dpkg-buildpackage'] + list(args)
     process_command(args, cwd=cwd)
 
 def dpkg_source(b_or_x,arg1,cwd=None):
@@ -1226,6 +1230,7 @@ def build_dsc(debinfo,
               remove_expanded_source_dir=0,
               debian_dir_only=False,
               sign_dsc=False,
+              ignore_source_changes=False,
               ):
     """make debian source package"""
     #    A. Find new dirname and delete any pre-existing contents
@@ -1433,12 +1438,15 @@ def build_dsc(debinfo,
     #    Re-generate tarball using best practices see
     #    http://www.debian.org/doc/developers-reference/ch-best-pkging-practices.en.html
 
-    if sign_dsc:
-        args = ()
-    else:
-        args = ('-uc','-us')
+    args = ['-S', '-sa']
 
-    dpkg_buildpackage('-S','-sa',*args,cwd=fullpath_repackaged_dirname)
+    if not sign_dsc:
+        args += ['-uc', '-us']
+
+    if ignore_source_changes:
+        args.append('-i.*')
+
+    dpkg_buildpackage(*args, cwd=fullpath_repackaged_dirname)
 
     if 1:
         shutil.rmtree(fullpath_repackaged_dirname)


### PR DESCRIPTION
This add a new option ignore-source-changes which is false by default.
This option can be used to force building a package even if there is
some changes in the source code.
It basically add -i.* to dpkg-buildpackage, which is then given to
dpkg-source.

Signed-off-by: Arnaud Morin <arnaud.morin@corp.ovh.com>