### PR TITLE
add configuration file option Python2-Depends-Name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -731,6 +731,8 @@ All available options:
   Setup-Env-Vars                       environment variables passed to
                                        setup.py
   Udev-Rules                           file with rules to install to udev
+  Python2-Depends-Name                 override Python 2 Debian package name in
+                                       ${python:Depends}
 ====================================== =========================================
 
 The option names in stdeb.cfg files are not case sensitive.

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -170,6 +170,7 @@ stdeb_cfg_options = [
     ('shared-mime-file=',None,'shared MIME file'),
     ('setup-env-vars=',None,'environment variables passed to setup.py'),
     ('udev-rules=',None,'file with rules to install to udev'),
+    ('python2-depends-name=',None,'Python 2 Debian package name used in ${python:Depends}'),
     ]
 
 stdeb_cmd_bool_opts = [
@@ -902,6 +903,8 @@ class DebianInfo:
             else:
                 self.patch_level = 0
 
+        python2_depends_name = parse_val(cfg,module_name,'Python2-Depends-Name')
+
         xs_python_version = parse_vals(cfg,module_name,'XS-Python-Version')
 
         if len(xs_python_version)!=0:
@@ -1096,8 +1099,14 @@ class DebianInfo:
         self.override_dh_auto_build = RULES_OVERRIDE_BUILD_TARGET%self.__dict__
         self.override_dh_auto_install = RULES_OVERRIDE_INSTALL_TARGET%self.__dict__
 
+        scripts = ''
+        if with_python2 and python2_depends_name:
+            scripts = (
+                '        sed -i ' +
+                '"s/\([ =]\)python[0-9]\?\(\(:any\)\? (\)/\\1%s\\2/g" ' +
+                'debian/%s.substvars') % (python2_depends_name, self.package)
         self.override_dh_python2 = RULES_OVERRIDE_PYTHON2%{
-            'scripts': ''
+            'scripts': scripts
         }
 
         if force_x_python3_version and with_python3 and x_python3_version and \

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1096,6 +1096,10 @@ class DebianInfo:
         self.override_dh_auto_build = RULES_OVERRIDE_BUILD_TARGET%self.__dict__
         self.override_dh_auto_install = RULES_OVERRIDE_INSTALL_TARGET%self.__dict__
 
+        self.override_dh_python2 = RULES_OVERRIDE_PYTHON2%{
+            'scripts': ''
+        }
+
         if force_x_python3_version and with_python3 and x_python3_version and \
                 x_python3_version[0]:
             # override dh_python3 target to modify the dependencies
@@ -1489,8 +1493,7 @@ RULES_MAIN = """\
 
 %(override_dh_auto_install)s
 
-override_dh_python2:
-        dh_python2 --no-guessing-versions
+%(override_dh_python2)s
 
 %(override_dh_python3)s
 
@@ -1522,6 +1525,11 @@ override_dh_auto_install:
 %(scripts_cleanup)s
 """
 
+RULES_OVERRIDE_PYTHON2 = """
+override_dh_python2:
+        dh_python2 --no-guessing-versions
+%(scripts)s
+"""
 RULES_OVERRIDE_PYTHON3 = """
 override_dh_python3:
         dh_python3


### PR DESCRIPTION
On Ubuntu Focal the Python 2 Debian package name is `python2`. So when generating Python 2 Debian package on Focal the `${python:Depends}` expands to something like `python2 (<< 2.8), python2 (>= 2.7)`.

With the new configuration option `Python2-Depends-Name` it can be configured to `python` which overrides the Debian package in `python:Depends`. The opposite (releasing on e.g. Ubuntu Bionic and configuring the override to `python2`) should also be feasible.