### PR TITLE
update debhelper compat version from 7 to 9

### DIFF
--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -126,8 +126,6 @@ class common_debian_package_command(Command):
         except DistutilsModuleError as err:
             use_setuptools = False
 
-        have_script_entry_points = None
-
         config_fname = 'stdeb.cfg'
         # Distutils fails if not run from setup.py dir, so this is OK.
         if os.path.exists(config_fname):
@@ -147,19 +145,6 @@ class common_debian_package_command(Command):
 
             egg_module_name = egg_info_dirname[:egg_info_dirname.index('.egg-info')]
             egg_module_name = egg_module_name.split(os.sep)[-1]
-
-            if 1:
-                # determine whether script specifies setuptools entry_points
-                ep_fname = os.path.join(egg_info_dirname,'entry_points.txt')
-                if os.path.exists(ep_fname):
-                    entry_points = open(ep_fname,'rU').readlines()
-                else:
-                    entry_points = ''
-                entry_points = [ep.strip() for ep in entry_points]
-
-                if ('[console_scripts]' in entry_points or
-                    '[gui_scripts]' in entry_points):
-                    have_script_entry_points = True
         else:
             # We don't have setuptools, so guess egg_info_dirname to
             # find old stdeb.cfg.
@@ -175,9 +160,6 @@ class common_debian_package_command(Command):
                              'stdeb.cfg in %s. This file will be used, but you '
                              'should move it alongside setup.py.' % entry)
                     cfg_files.append(config_fname)
-
-        if have_script_entry_points is None:
-            have_script_entry_points = self.distribution.has_scripts()
 
         upstream_version = self.distribution.get_version()
         bad_chars = ':_'
@@ -211,7 +193,6 @@ class common_debian_package_command(Command):
             patch_file = self.patch_file,
             patch_level = self.patch_level,
             debian_version = self.debian_version,
-            have_script_entry_points = have_script_entry_points,
             setup_requires = (), # XXX How do we get the setup_requires?
             use_setuptools = use_setuptools,
             guess_conflicts_provides_replaces=self.guess_conflicts_provides_replaces,

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -25,8 +25,7 @@ __all__ = ['DebianInfo','build_dsc','expand_tarball','expand_zip',
            'apply_patch','repack_tarball_with_debianized_dirname',
            'expand_sdist_file','stdeb_cfg_options']
 
-DH_MIN_VERS = '7'       # Fundamental to stdeb >= 0.4
-DH_IDEAL_VERS = '7.4.3' # fixes Debian bug 548392
+DH_MIN_VERS = '9'  # Fundamental to stdeb >= 0.10
 
 PYTHON_ALL_MIN_VERS = '2.6.6-3'
 
@@ -698,7 +697,6 @@ class DebianInfo:
                  patch_level=None,
                  setup_requires=None,
                  debian_version=None,
-                 have_script_entry_points = None,
                  use_setuptools = False,
                  guess_conflicts_provides_replaces = False,
                  sdist_dsc_command = None,
@@ -871,10 +869,7 @@ class DebianInfo:
         else:
             self.long_description = ''
 
-        if have_script_entry_points:
-            build_deps.append( 'debhelper (>= %s)'%DH_IDEAL_VERS )
-        else:
-            build_deps.append( 'debhelper (>= %s)'%DH_MIN_VERS )
+        build_deps.append( 'debhelper (>= %s)'%DH_MIN_VERS )
 
         build_deps.extend( parse_vals(cfg,module_name,'Build-Depends') )
         self.build_depends = ', '.join(build_deps)
@@ -1333,7 +1328,7 @@ def build_dsc(debinfo,
 
     #    D. debian/compat
     fd = open( os.path.join(debian_dir,'compat'), mode='w')
-    fd.write('7\n')
+    fd.write('9\n')
     fd.close()
 
     #    E. debian/package.mime
@@ -1424,7 +1419,7 @@ def build_dsc(debinfo,
             if not dpkg_compare_versions(
                 debhelper_version_str, 'ge', DH_MIN_VERS ):
                 log.warn('This version of stdeb requires debhelper >= %s. '
-                         'Use stdeb 0.3.x to generate source packages '
+                         'Use stdeb 0.9.x to generate source packages '
                          'compatible with older versions of debhelper.'%(
                     DH_MIN_VERS,))
 


### PR DESCRIPTION
This avoid deprecation warnings on current platforms and should be compatible with all platforms still being supported.