### PR TITLE
feat: added flag --with-dh-systemd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -598,7 +598,7 @@ To pass these commands to sdist_dsc when calling bdist_deb, do this::
                                        /some/random/virtualenv-path
   --with-dh-virtualenv                 Build the package using dh_virtualenv, so all dependencies
                                        are embedded into the packages.
-  --with-dh-system                     Adds the systemd addon that will  dh_systemd_enable and
+  --with-dh-systemd                    Add the systemd addon that will add dh_systemd_enable and
                                        dh_systemd_start helpers at the correct time during build.
   --sign-results                       Use gpg to sign the resulting .dsc and
                                        .changes file

--- a/README.rst
+++ b/README.rst
@@ -598,6 +598,8 @@ To pass these commands to sdist_dsc when calling bdist_deb, do this::
                                        /some/random/virtualenv-path
   --with-dh-virtualenv                 Build the package using dh_virtualenv, so all dependencies
                                        are embedded into the packages.
+  --with-dh-system                     Adds the systemd addon that will  dh_systemd_enable and
+                                       dh_systemd_start helpers at the correct time during build.
   --sign-results                       Use gpg to sign the resulting .dsc and
                                        .changes file
   --dist-dir (-d)                      directory to put final built

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -32,6 +32,7 @@ class common_debian_package_command(Command):
         self.force_x_python3_version = False
         self.allow_virtualenv_install_location = False
         self.with_dh_virtualenv = False
+        self.with_dh_systemd = False
         self.sign_results = False
         self.ignore_source_changes = False
 
@@ -223,5 +224,6 @@ class common_debian_package_command(Command):
             force_x_python3_version=self.force_x_python3_version,
             allow_virtualenv_install_location=self.allow_virtualenv_install_location,
             with_dh_virtualenv=self.with_dh_virtualenv,
+            with_dh_systemd=self.with_dh_systemd,
         )
         return debinfo

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -111,6 +111,9 @@ stdeb_cmdline_opts = [
      'Use dh_virtualenv to build the package instead of python_distutils. '
      'This is useful to embed an application with all its dependencies '
      'and dont touch to the system libraries.'),
+    ('with-dh-systemd', None,
+     'Adds the systemd addon that will dh_systemd_enable and'
+     'dh_systemd_start helpers at the correct time during build.'),
     ('sign-results',None,
      'Use gpg to sign the resulting .dsc and .changes file'),
     ('ignore-source-changes',None,
@@ -189,6 +192,7 @@ stdeb_cmd_bool_opts = [
     'force-x-python3-version',
     'allow-virtualenv-install-location',
     'with-dh-virtualenv',
+    'with-dh-systemd',
     'sign-results',
     'ignore-source-changes',
     ]
@@ -709,6 +713,7 @@ class DebianInfo:
                  force_x_python3_version=False,
                  allow_virtualenv_install_location=False,
                  with_dh_virtualenv=False,
+                 with_dh_systemd=False,
                  ):
         if cfg_files is NotGiven: raise ValueError("cfg_files must be supplied")
         if module_name is NotGiven: raise ValueError(
@@ -1141,6 +1146,9 @@ class DebianInfo:
             sequencer_options.append('--with python-virtualenv')
         else:
             sequencer_options.append('--buildsystem=python_distutils')
+
+        if with_dh_systemd:
+            sequencer_options.append('--with systemd')
 
         self.sequencer_options = ' '.join(sequencer_options)
 


### PR DESCRIPTION
feat: added flag --with-dh-systemd to pass on the flag to rules so units can get enabled at install time when compat level is <7 as hardcoded right now