### PR TITLE
dh_virtualenv: specify python version 

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1146,6 +1146,7 @@ class DebianInfo:
             sequencer_options.append('--with python-virtualenv')
         else:
             sequencer_options.append('--buildsystem=python_distutils')
+            self.override_dh_virtualenv_py = ''
 
         self.sequencer_options = ' '.join(sequencer_options)
 

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1225,7 +1225,7 @@ class DebianInfo:
                 elif value == '<same-as-suite>':
                     assert key=='suite3'
                     # Set to empty string so value of suite is used.
-                    value = ''
+                    value = '' 
                 if key=='suite':
                     if default_distribution is not None:
                         value = default_distribution

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1138,6 +1138,11 @@ class DebianInfo:
         sequencer_options = ['--with '+','.join(sequencer_with)]
 
         if with_dh_virtualenv:
+            if with_python2:
+                self.override_dh_virtualenv_py = RULES_OVERRIDE_DH_VIRTUALENV_PY2%self.__dict__
+            if with_python3:
+                self.override_dh_virtualenv_py = RULES_OVERRIDE_DH_VIRTUALENV_PY3%self.__dict__
+
             sequencer_options.append('--with python-virtualenv')
         else:
             sequencer_options.append('--buildsystem=python_distutils')
@@ -1219,7 +1224,7 @@ class DebianInfo:
                 elif value == '<same-as-suite>':
                     assert key=='suite3'
                     # Set to empty string so value of suite is used.
-                    value = '' 
+                    value = ''
                 if key=='suite':
                     if default_distribution is not None:
                         value = default_distribution
@@ -1534,6 +1539,8 @@ RULES_MAIN = """\
 
 %(override_dh_python3)s
 
+%(override_dh_virtualenv_py)s
+
 %(binary_target_lines)s
 """
 
@@ -1571,6 +1578,16 @@ RULES_OVERRIDE_PYTHON3 = """
 override_dh_python3:
         dh_python3
 %(scripts)s
+"""
+
+RULES_OVERRIDE_DH_VIRTUALENV_PY2 = """
+override_dh_virtualenv:
+        dh_virtualenv --python python2
+"""
+
+RULES_OVERRIDE_DH_VIRTUALENV_PY3 = """
+override_dh_virtualenv:
+        dh_virtualenv --python python3
 """
 
 RULES_BINARY_TARGET = """


### PR DESCRIPTION
Specifies the python version to use for `dh_virtualenv` (As indicated with the [`dh_virtualenv` documentation](https://dh-virtualenv.readthedocs.io/en/latest/howtos.html#building-packages-for-python3))