### PR TITLE
use SOURCE_DATE_EPOCH if set for timestamp in generated changelog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -759,6 +759,20 @@ All available options:
 
 The option names in stdeb.cfg files are not case sensitive.
 
+Reproducible builds
+-------------------
+
+By default stdeb uses the current time for the the timestamp in the generated
+changelog file. This results in a non-reproducible build since every invocation
+generates a different changelog / ``.deb``.
+The environment variable ``SOURCE_DATE_EPOCH`` can be set to a fixed timestamp
+(e.g. when the version was tagged or of the last commit was made) which will be
+used in the changelog instead. This will ensure that the produced ``.deb`` is
+reproducible on repeated invocations.
+
+For more information about reproducible builds and this specific environment
+variable please see https://reproducible-builds.org/docs/source-date-epoch/
+
 Prerequisites
 -------------
 

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -263,7 +263,11 @@ def get_cmd_stdout(args):
 
 def get_date_822():
     """return output of 822-date command"""
-    t = time.localtime()
+    source_date_epoch = os.environ.get('SOURCE_DATE_EPOCH', None)
+    if source_date_epoch:
+        t = time.gmtime(int(source_date_epoch))
+    else:
+        t = time.localtime()
     return time.strftime(calendar.day_abbr[t.tm_wday]+ ", %d " + calendar.month_abbr[t.tm_mon] + " %Y %H:%M:%S %z", t)
 
 def get_version_str(pkg):


### PR DESCRIPTION
See https://reproducible-builds.org/docs/source-date-epoch/

By default the timestamp in the generated changelog is *now* which results in a non-reproducible build since every invocation generates a different `.deb`. With this patch the caller can set the environment variable `SOURCE_DATE_EPOCH` to e.g. the timestamp of the tagged commit to ensure that the produced `.deb` is reproducible (byte-wise identical).