### PR TITLE
use setuptools "url" field for "Homepage" field in debian/control

### DIFF
--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -195,6 +195,7 @@ class common_debian_package_command(Command):
             has_ext_modules = self.distribution.has_ext_modules(),
             description = description,
             long_description = long_description,
+            homepage = self.distribution.get_url(),
             patch_file = self.patch_file,
             patch_level = self.patch_level,
             debian_version = self.debian_version,

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -701,6 +701,7 @@ class DebianInfo:
                  has_ext_modules=NotGiven,
                  description=NotGiven,
                  long_description=NotGiven,
+                 homepage=NotGiven,
                  patch_file=None,
                  patch_level=None,
                  setup_requires=None,
@@ -732,6 +733,8 @@ class DebianInfo:
             "description must be supplied")
         if long_description is NotGiven: raise ValueError(
             "long_description must be supplied")
+        if homepage is NotGiven: raise ValueError(
+            "homepage must be supplied")
 
         cfg_defaults = self._make_cfg_defaults(
             module_name=module_name,
@@ -889,6 +892,9 @@ class DebianInfo:
         recommends3 = ', '.join( parse_vals(cfg,module_name,'Recommends3') )
 
         self.source_stanza_extras = ''
+
+        if homepage != 'UNKNOWN':
+            self.source_stanza_extras += 'Homepage: %s\n' % homepage
 
         build_conflicts = parse_vals(cfg,module_name,'Build-Conflicts')
         if len(build_conflicts):


### PR DESCRIPTION
This is a rebase of #103 and the "Homepage: ..." is being added to the `source_stanza_extras` variable instead of adding another placeholder to the template.