### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -501,7 +501,7 @@ to install a more recent stdeb.
   STDEB_VERSION="0.10.0"
 
   # Download stdeb
-  wget httpd://pypi.python.org/packages/source/s/stdeb/stdeb-$STDEB_VERSION.tar.gz
+  wget https://pypi.python.org/packages/source/s/stdeb/stdeb-$STDEB_VERSION.tar.gz
 
   # Extract it
   tar xzf stdeb-$STDEB_VERSION.tar.gz

--- a/README.rst
+++ b/README.rst
@@ -501,7 +501,7 @@ to install a more recent stdeb.
   STDEB_VERSION="0.10.0"
 
   # Download stdeb
-  wget http://pypi.python.org/packages/source/s/stdeb/stdeb-$STDEB_VERSION.tar.gz
+  wget httpd://pypi.python.org/packages/source/s/stdeb/stdeb-$STDEB_VERSION.tar.gz
 
   # Extract it
   tar xzf stdeb-$STDEB_VERSION.tar.gz


### PR DESCRIPTION
change download to https as http is no longer available. Newer versions of wget will automaticalle switch to https duo to HSCP but old ones will simple fail.

In either way, the url should use https.