### PR TITLE
allow specifying signing key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -622,6 +622,7 @@ To pass these commands to sdist_dsc when calling bdist_deb, do this::
                                        dh_systemd_start helpers at the correct time during build.
   --sign-results                       Use gpg to sign the resulting .dsc and
                                        .changes file
+  --sign-key                           Specify signing key
   --dist-dir (-d)                      directory to put final built
                                        distributions in (default='deb_dist')
   --patch-already-applied (-a)         patch was already applied (used when

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -35,6 +35,7 @@ class common_debian_package_command(Command):
         self.with_dh_virtualenv = False
         self.with_dh_systemd = False
         self.sign_results = False
+        self.sign_key = None
         self.ignore_source_changes = False
         self.compat = DH_DEFAULT_VERS
 

--- a/stdeb/command/sdist_dsc.py
+++ b/stdeb/command/sdist_dsc.py
@@ -141,6 +141,7 @@ class sdist_dsc(common_debian_package_command):
                   patch_posix=self.patch_posix,
                   remove_expanded_source_dir=self.remove_expanded_source_dir,
                   sign_dsc=self.sign_results,
+                  sign_key=self.sign_key,
                   ignore_source_changes=self.ignore_source_changes,
                   )
 

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -132,6 +132,8 @@ stdeb_cmdline_opts = [
      'dh_systemd_start helpers at the correct time during build.'),
     ('sign-results', None,
      'Use gpg to sign the resulting .dsc and .changes file'),
+    ('sign-key=', None,
+     'Specify signing key'),
     ('ignore-source-changes', None,
      'Ignore all changes on source when building source package (add -i.* '
      'option to dpkg-source)'),
@@ -1336,6 +1338,7 @@ def build_dsc(debinfo,
               remove_expanded_source_dir=0,
               debian_dir_only=False,
               sign_dsc=False,
+              sign_key=None,
               ignore_source_changes=False,
               ):
     """make debian source package"""
@@ -1562,6 +1565,8 @@ def build_dsc(debinfo,
 
     if not sign_dsc:
         args += ['-uc', '-us']
+    elif sign_key is not None:
+        args += ['--sign-key={}'.format(sign_key)]
 
     if ignore_source_changes:
         args.append('-i.*')


### PR DESCRIPTION
Allows user to specify a specific GPG key with `--sign-key KEYNAME` instead of always using the default key.