### PR TITLE
added function to use debian custom scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://travis-ci.org/astraw/stdeb.png?branch=master
-        :target: https://travis-ci.org/astraw/stdeb
-
 stdeb - Python to Debian source package conversion utility
 ==========================================================
 
@@ -51,6 +48,11 @@ interpreter (and only the Python3 package installs scripts)::
 
 News
 ----
+ * 2022-08-12: **Version 0.11.0**.
+
+  * Improvements:
+
+    * add support for debian folder containing postinst and other scripts for bdist_deb
 
  * 2020-10-28: **Version 0.10.0**. See the `download page
    <https://pypi.python.org/pypi/stdeb/0.10.0>`__.

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ setup(
     name='stdeb',
     # Keep version in sync with stdeb/__init__.py and install section
     # of README.rst.
-    version='0.10.0',
-    author='Andrew Straw',
-    author_email='strawman@astraw.com',
+    version='0.11.0',
+    author='Daniel Bisar',
+    author_email='3024016+danielbisar@users.noreply.github.com',
     description='Python to Debian source package conversion utility',
     long_description=long_description,
     license='MIT',
-    url='http://github.com/astraw/stdeb',
+    url='http://github.com/daniel.bisar/stdeb',
     packages=['stdeb', 'stdeb.command'],
     scripts=[
         'scripts/py2dsc',

--- a/stdeb/__init__.py
+++ b/stdeb/__init__.py
@@ -1,5 +1,5 @@
 import logging
-__version__ = '0.10.0'  # keep in sync with ../setup.py
+__version__ = '0.11.0'  # keep in sync with ../setup.py
 
 log = logging.getLogger('stdeb')
 log.setLevel(logging.INFO)

--- a/stdeb/command/bdist_deb.py
+++ b/stdeb/command/bdist_deb.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import stdeb.util as util
 
 from distutils.core import Command
@@ -55,6 +56,18 @@ class bdist_deb(Command):
         if len(target_dirs) == 0:
             raise ValueError('could not find debian source directory')
 
+        target_dir = target_dirs[0]
+        self.check_for_and_copy_custom_debian_scripts(target_dir)
+        self.generate_debian_pkg(target_dir)
+
+    def check_for_and_copy_custom_debian_scripts(self, target_dir: str):
+        custom_debian_folder = os.path.join(os.getcwd(), 'debian')
+
+        if os.path.exists(custom_debian_folder):
+            print("STDEB: Found custom debian folder, copying to target directory " + target_dir)
+            shutil.copytree(custom_debian_folder, os.path.join(target_dir, 'debian'), dirs_exist_ok=True)
+
+    def generate_debian_pkg(self, target_dir: str):
         # define system command to execute (gen .deb binary pkg)
         syscmd = ['dpkg-buildpackage', '-rfakeroot', '-b']
 
@@ -64,4 +77,5 @@ class bdist_deb(Command):
         if self.ignore_source_changes:
             syscmd.append('-i.*')
 
-        util.process_command(syscmd, cwd=target_dirs[0])
+        print('CALLING ' + ' '.join(syscmd))
+        util.process_command(syscmd, cwd=target_dir)


### PR DESCRIPTION
Related issues

https://github.com/astraw/stdeb/issues/132
https://github.com/astraw/stdeb/issues/46

I tried to keep it simple. So I just check in case of bdist_deb if the debian folder exists in the repo (next to the python module folder) and it copies all files present there before executing dpkg-buildpackage. Basically the idea is based on the workaround mentioned in https://github.com/astraw/stdeb/issues/46

There is another PR which adds these scripts as options, but this cannot be merged and is from 2012 https://github.com/astraw/stdeb/pull/50
