### PR TITLE
README: Replace wget calls with pypi-download

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -412,7 +412,7 @@ Quickstart 3: I read the warning, so show me how to make a source package, then 
 
 This generates a source package::
 
-  wget http://pypi.python.org/packages/source/R/Reindent/Reindent-0.1.0.tar.gz
+  pypi-download Reindent --release=0.1.0
   py2dsc Reindent-0.1.0.tar.gz
 
 This turns it into a .deb using the standard Debian tools. (Do *this*
@@ -449,7 +449,7 @@ illustration, we do download such a tarball, but immediately unpack it
 (alternatively, use a version control system to grab the unpacked
 source of a package)::
 
-  wget http://pypi.python.org/packages/source/R/Reindent/Reindent-0.1.0.tar.gz
+  pypi-download Reindent --release=0.1.0
   tar xzf Reindent-0.1.0.tar.gz
   cd Reindent-0.1.0
 
@@ -501,7 +501,7 @@ to install a more recent stdeb.
   STDEB_VERSION="0.10.0"
 
   # Download stdeb
-  wget https://pypi.python.org/packages/source/s/stdeb/stdeb-$STDEB_VERSION.tar.gz
+  pypi-download stdeb --release=$STDEB_VERSION
 
   # Extract it
   tar xzf stdeb-$STDEB_VERSION.tar.gz


### PR DESCRIPTION
There are two issues that this PR fixes:

- The URL that is retrieved using wget doesn't exist. These URLs were placed in the README 13 years ago, so I think it's likely that PyPI has changed the structure at some point.
- Although it is not literally stated in the README, I take it that `pypi-download` should be used to download source files from PyPI, instead of wgetting them. According to the changelog, `pypi-download` was added in version 0.7.1 (2014), so I think it's likely that updating the README was simply forgotten when this tool was introduced.