### PR TITLE
Migrate off SafeConfigParser

### DIFF
--- a/stdeb/cli_runner.py
+++ b/stdeb/cli_runner.py
@@ -3,12 +3,7 @@ import os
 import shutil
 import subprocess
 import sys
-try:
-    # python 2.x
-    from ConfigParser import SafeConfigParser  # noqa: F401
-except ImportError:
-    # python 3.x
-    from configparser import SafeConfigParser  # noqa: F401
+from configparser import ConfigParser  # noqa: F401
 from distutils.util import strtobool
 from distutils.fancy_getopt import FancyGetopt, translate_longopt
 from stdeb.util import stdeb_cmdline_opts, stdeb_cmd_bool_opts

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -801,7 +801,7 @@ class DebianInfo:
         cfg = ConfigParser.ConfigParser(cfg_defaults)
         for cfg_file in cfg_files:
             with codecs.open(cfg_file, mode='r', encoding='utf-8') as fd:
-                cfg.readfp(fd)
+                cfg.read_file(fd)
 
         if sdist_dsc_command is not None:
             # Allow distutils commands to override config files (this lets

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -9,12 +9,7 @@ import shutil
 import sys
 import time
 import codecs
-try:
-    # Python 2.x
-    import ConfigParser
-except ImportError:
-    # Python 3.x
-    import configparser as ConfigParser
+import configparser as ConfigParser
 import subprocess
 import tempfile
 import stdeb  # noqa: F401
@@ -732,7 +727,7 @@ def check_cfg_files(cfg_files, module_name):
     example.
     """
 
-    cfg = ConfigParser.SafeConfigParser()
+    cfg = ConfigParser.ConfigParser()
     cfg.read(cfg_files)
     if cfg.has_section(module_name):
         section_items = cfg.items(module_name)
@@ -803,7 +798,7 @@ class DebianInfo:
         if len(cfg_files):
             check_cfg_files(cfg_files, module_name)
 
-        cfg = ConfigParser.SafeConfigParser(cfg_defaults)
+        cfg = ConfigParser.ConfigParser(cfg_defaults)
         for cfg_file in cfg_files:
             with codecs.open(cfg_file, mode='r', encoding='utf-8') as fd:
                 cfg.readfp(fd)


### PR DESCRIPTION
`SafeConfigParser` has been deprecated since Python 3.2. There has been a shim which has been finally removed in Python 3.11 [in this commit](https://github.com/python/cpython/commit/1fc41ae8709e20d741bd86c2345173688a5e84b0) in favor of simply `ConfigParser`.

This means that this utility won't work if users are on Python >= 3.11 (which is the case for Ubuntu Noble).
In this PR I migrated to `ConfigParser` and took the liberty to remove the `try except` that made the package work for Python 2 since Python 2 is been EOL for more than 4 years now (this fix would have been more boilerplate otherwise).

`readfp` was also deprecated in favor of `read_file`.

## Test it!

Try building a package on Ubuntu 22.04, then try on Ubuntu 24.04. For example, when
trying to build [colcon-cmake](https://github.com/colcon/colcon-cmake/) using the [publish-python](https://github.com/dirk-thomas/publish-python) utility, the output under Ubuntu 24.04 is:

```
~/colcon-cmake$ ../publish-python/bin/publish-python 
[CUT]
== Creating 'stdeb' artifacts ...

-- Building sdist_dsc and bdist_deb package ...
$ /usr/bin/python3 setup.py --command-packages=stdeb.command sdist_dsc --source python3-colcon-cmake --with-python3 true --with-python2 false --force-x-python3-version bdist_deb 
running sdist_dsc
running egg_info
writing colcon_cmake.egg-info/PKG-INFO
writing dependency_links to colcon_cmake.egg-info/dependency_links.txt
writing entry points to colcon_cmake.egg-info/entry_points.txt
writing requirements to colcon_cmake.egg-info/requires.txt
writing top-level names to colcon_cmake.egg-info/top_level.txt
reading manifest file 'colcon_cmake.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'colcon_cmake.egg-info/SOURCES.txt'
Traceback (most recent call last):
  File "/home/lucadv/colcon-cmake/setup.py", line 6, in <module>
    setup()
  File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 107, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 185, in setup
    return run_commands(dist)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 201, in run_commands
    dist.run_commands()
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 969, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1233, in run_command
    super().run_command(command)
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "/usr/lib/python3/dist-packages/stdeb/command/sdist_dsc.py", line 30, in run
    debinfo = self.get_debinfo()
              ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/stdeb/command/common.py", line 197, in get_debinfo
    debinfo = DebianInfo(
              ^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/stdeb/util.py", line 802, in __init__
    check_cfg_files(cfg_files, module_name)
  File "/usr/lib/python3/dist-packages/stdeb/util.py", line 733, in check_cfg_files
    cfg = ConfigParser.SafeConfigParser()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
Traceback (most recent call last):
  File "/home/lucadv/colcon-cmake/../publish-python/bin/publish-python", line 24, in <module>
    rc = main()
         ^^^^^^
  File "/home/lucadv/publish-python/publish_python/cli.py", line 77, in main
    artifacts = artifact_handlers[artifact_type](config=artifact.config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucadv/publish-python/publish_python/artifact/stdeb.py", line 44, in create_deb
    subprocess.check_call(cmd, env=dict(os.environ, **add_env))
  File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/usr/bin/python3', 'setup.py', '--command-packages=stdeb.command', 'sdist_dsc', '--source', 'python3-colcon-cmake', '--with-python3', 'true', '--with-python2', 'false', '--force-x-python3-version', 'bdist_deb']' returned non-zero exit status 1.
```

Now try the PR code:

* `sudo apt remove python3-stdeb`.
* `pip install git+https://github.com/luca-della-vedova/stdeb@luca/migrate_configparser --break-system-packages`
* rebuild the package
* It works!