### PR TITLE
Raise the minimum python version to 3.7.3-1.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,24 @@ interpreter (and only the Python3 package installs scripts)::
 
 News
 ----
+ * FUTURE: **Version 0.11.0**. See the `download page
+   <https://pypi.python.org/pypi/stdeb/0.11.0>`__.
+
+  * Breaking changes:
+
+    * Remove support for running stdeb using Python 2.
+      stdeb scripts are now only expected to run using Python 3. It may be
+      possible to create Python 2 packages using stdeb from Python 3 but this
+      is not well tested. The new minimum Python version is 3.7 and this will
+      be raised periodically in the future. The goal is to support the latest
+      Python 3 releases in Debian Unstable and Testing back to the current
+      oldoldstable.
+    * Minimum debhelper version has been raised to 12.
+      Packages are now built using pybuild instead of of python_distutils.
+      The minimum debhelper version will be raised periodically in order
+      to support changes to packaging infrastructure but we will try not
+      to raise it above the current oldoldstable version.
+
  * 2025-07-31: **Version 0.10.2**. See the `download page
    <https://pypi.python.org/pypi/stdeb/0.10.2>`__.
    This is a bugfix release for 0.10.1 which fixes a regression.
@@ -59,13 +77,6 @@ News
 
     * Add a shim function for which on python2. (#215)
       * Fixes a regression introduced in  #203.
-
- * 2024-07-03: **Version 0.11.0**. See the `download page
-   <https://pypi.python.org/pypi/stdeb/0.11.0>`__.
-
-  * Breaking changes:
-
-    * remove support for running stdeb using Python 2.
 
  * 2024-11-14: **Version 0.10.1**. See the `download page
    <https://pypi.python.org/pypi/stdeb/0.10.1>`__.

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,13 @@ News
     * Add a shim function for which on python2. (#215)
       * Fixes a regression introduced in  #203.
 
+ * 2024-07-03: **Version 0.11.0**. See the `download page
+   <https://pypi.python.org/pypi/stdeb/0.11.0>`__.
+
+  * Breaking changes:
+
+    * remove support for running stdeb using Python 2.
+
  * 2024-11-14: **Version 0.10.1**. See the `download page
    <https://pypi.python.org/pypi/stdeb/0.10.1>`__.
    This is the last planned release of stdeb which supports running stdeb

--- a/build.earth
+++ b/build.earth
@@ -17,7 +17,7 @@ BUILD:
 		debhelper dh-python python3-all python3-pip python3-setuptools \
 		# Install deps \
 		python3-requests apt-file \
-    # Pip install deps \
+		# Pip install deps \
 		python3-venv \
 		# Test deps \
 		libpq-dev python3-all-dev
@@ -33,7 +33,7 @@ INSTALL:
 
 PIP_INSTALL:
 	FUNCTION
-  RUN python3 -m venv venv
+	RUN python3 -m venv venv
 	RUN . venv/bin/activate && pip install .
 
 lint:

--- a/build.earth
+++ b/build.earth
@@ -17,6 +17,8 @@ BUILD:
 		debhelper dh-python python3-all python3-pip python3-setuptools \
 		# Install deps \
 		python3-requests apt-file \
+    # Pip install deps \
+		python3-venv \
 		# Test deps \
 		libpq-dev python3-all-dev
 
@@ -28,6 +30,11 @@ INSTALL:
 	FUNCTION
 	# Install stdeb
 	RUN dpkg -i deb_dist/*.deb
+
+PIP_INSTALL:
+	FUNCTION
+  RUN python3 -m venv venv
+	RUN . venv/bin/activate && pip install .
 
 lint:
 	FROM docker.io/library/python:3.10-alpine
@@ -41,10 +48,16 @@ build:
 	FROM $OS
 	DO +BUILD
 
+test-stdeb-from-pip:
+	FROM +build
+	DO +PIP_INSTALL
+	RUN . venv/bin/activate && PYEXE=$(command -v python3) bash -x ./test.sh
+
 test:
 	FROM +build
 	DO +INSTALL
 	RUN env PYEXE=/usr/bin/python3 bash -x  ./test.sh
+
 
 test-pypi-install:
 	FROM +build

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -30,6 +30,7 @@ DH_MIN_VERS = '9'  # Fundamental to stdeb >= 0.10
 DH_DEFAULT_VERS = 9
 
 # Choose the oldest from Debian oldoldstable and currently supported Ubuntu LTS
+PYTHON_ALL_MIN_VERS = '2.7.16-1'
 PYTHON3_ALL_MIN_VERS = '3.7.3-1'
 
 try:
@@ -862,10 +863,6 @@ class DebianInfo:
         self.maintainer = ', '.join(parse_vals(cfg, module_name, 'Maintainer'))
         self.uploaders = parse_vals(cfg, module_name, 'Uploaders')
         self.date822 = get_date_822()
-
-        if with_python2:
-            log.error("Python 2 is no longer supported. Use stdeb <= 0.10.0 for Python 2")
-            sys.exit(1)
 
         build_deps = []
         if use_setuptools:

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1680,7 +1680,7 @@ override_dh_auto_build:
 
 RULES_OVERRIDE_INSTALL_TARGET_PY2 = "        %(python2_binname)s setup.py install --force --root=debian/%(package)s --no-compile -O0 --install-layout=deb %(install_prefix)s %(no_python2_scripts_cli_args)s"  # noqa: E501
 
-RULES_OVERRIDE_INSTALL_TARGET_PY3 = "        python3 setup.py install --force --root=debian/%(package3)s --no-compile -O0 %(install_prefix)s %(no_python3_scripts_cli_args)s"  # noqa: E501
+RULES_OVERRIDE_INSTALL_TARGET_PY3 = "        python3 setup.py install --force --root=debian/%(package3)s --no-compile -O0 --install-layout=deb %(install_prefix)s %(no_python3_scripts_cli_args)s"  # noqa: E501
 
 RULES_OVERRIDE_INSTALL_TARGET = """
 override_dh_auto_install:

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -26,8 +26,8 @@ __all__ = ['DebianInfo', 'build_dsc', 'expand_tarball', 'expand_zip',
            'apply_patch', 'repack_tarball_with_debianized_dirname',
            'expand_sdist_file', 'stdeb_cfg_options']
 
-DH_MIN_VERS = '9'  # Fundamental to stdeb >= 0.10
-DH_DEFAULT_VERS = 9
+DH_MIN_VERS = '12'  # Fundamental to stdeb >= 0.10
+DH_DEFAULT_VERS = 12
 
 # Choose the oldest from Debian oldoldstable and currently supported Ubuntu LTS
 PYTHON_ALL_MIN_VERS = '2.7.16-1'
@@ -1233,7 +1233,7 @@ class DebianInfo:
 
             sequencer_options.append('--with python-virtualenv')
         else:
-            sequencer_options.append('--buildsystem=python_distutils')
+            sequencer_options.append('--buildsystem=pybuild')
             self.override_dh_virtualenv_py = ''
 
         if with_dh_systemd:
@@ -1562,6 +1562,14 @@ def build_dsc(debinfo,
             if len(python3_defaults_version_str) == 0:
                 log.warn('This version of stdeb requires python3-all, '
                          'but you do not have this package installed.')
+            else:
+                if not dpkg_compare_versions(
+                    python3_defaults_version_str, 'ge', PYTHON3_ALL_MIN_VERS
+                ):
+                    log.warn('This version of stdeb requires python-all >= '
+                             '%s. Use stdeb 0.6.0 or older to generate source '
+                             'packages that use python-support.' % (
+                                 PYTHON_ALL_MIN_VERS,))
 
     #    D. restore debianized tree
     os.rename(fullpath_repackaged_dirname+'.debianized',

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -29,7 +29,8 @@ __all__ = ['DebianInfo', 'build_dsc', 'expand_tarball', 'expand_zip',
 DH_MIN_VERS = '9'  # Fundamental to stdeb >= 0.10
 DH_DEFAULT_VERS = 9
 
-PYTHON_ALL_MIN_VERS = '2.6.6-3'
+# Choose the oldest from Debian oldoldstable and currently supported Ubuntu LTS
+PYTHON3_ALL_MIN_VERS = '3.7.3-1'
 
 try:
     # Python 2.x
@@ -861,6 +862,10 @@ class DebianInfo:
         self.maintainer = ', '.join(parse_vals(cfg, module_name, 'Maintainer'))
         self.uploaders = parse_vals(cfg, module_name, 'Uploaders')
         self.date822 = get_date_822()
+
+        if with_python2:
+            log.error("Python 2 is no longer supported. Use stdeb <= 0.10.0 for Python 2")
+            sys.exit(1)
 
         build_deps = []
         if use_setuptools:

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1680,7 +1680,7 @@ override_dh_auto_build:
 
 RULES_OVERRIDE_INSTALL_TARGET_PY2 = "        %(python2_binname)s setup.py install --force --root=debian/%(package)s --no-compile -O0 --install-layout=deb %(install_prefix)s %(no_python2_scripts_cli_args)s"  # noqa: E501
 
-RULES_OVERRIDE_INSTALL_TARGET_PY3 = "        python3 setup.py install --force --root=debian/%(package3)s --no-compile -O0 --install-layout=deb %(install_prefix)s %(no_python3_scripts_cli_args)s"  # noqa: E501
+RULES_OVERRIDE_INSTALL_TARGET_PY3 = "        python3 setup.py install --force --root=debian/%(package3)s --no-compile -O0 %(install_prefix)s %(no_python3_scripts_cli_args)s"  # noqa: E501
 
 RULES_OVERRIDE_INSTALL_TARGET = """
 override_dh_auto_install:

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1615,7 +1615,7 @@ Maintainer: %(maintainer)s
 %(uploaders)sSection: %(debian_section)s
 Priority: optional
 Build-Depends: %(build_depends)s
-Standards-Version: 3.9.1
+Standards-Version: 4.7.0
 %(source_stanza_extras)s
 
 %(control_py2_stanza)s

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -26,7 +26,7 @@ __all__ = ['DebianInfo', 'build_dsc', 'expand_tarball', 'expand_zip',
            'apply_patch', 'repack_tarball_with_debianized_dirname',
            'expand_sdist_file', 'stdeb_cfg_options']
 
-DH_MIN_VERS = '12'  # Fundamental to stdeb >= 0.10
+DH_MIN_VERS = '12'  # Fundamental to stdeb >= 0.11
 DH_DEFAULT_VERS = 12
 
 # Choose the oldest from Debian oldoldstable and currently supported Ubuntu LTS

--- a/test-pypi-install.sh
+++ b/test-pypi-install.sh
@@ -7,7 +7,8 @@ if [ "$UID" -ne "0" ]; then
 fi
 
 # Package with source tarball on PyPI:
-pypi-install pyflakes --verbose=2
+# Later versions of pyflakes fail to build on Ubuntu Focal
+pypi-install pyflakes --verbose=2 --release=3.2.0
 dpkg --purge python-pyflakes
 
 # This test fails on Ubuntu 12.04 due to what looks like a bug with


### PR DESCRIPTION
This change is the start of:
* ~~Dropping support for Python 2~~ Dropping support for running stdeb scripts as python2.
* Dropping support for Debian older than Buster (oldoldstable)
* Dropping support for Ubuntu older than Focal (20.04)

Further commits will update the minimum debhelper version and Debian Standards version. It's the debhelper bump which motivated dropping support for Ubuntu Bionic.

I'm going to attempt to preserve support for generating python2 package data using stdeb on python3. However, my capacity to test such changes and my personal need in packaging python2 projects is severely limited. I'll be very happy to review contributions that support this if I cannot make it work myself.

Resolves #192 