### PR TITLE
Fix cyclic import dependency by moving USER_AGENT to pypi_simple client.

### DIFF
--- a/stdeb/downloader.py
+++ b/stdeb/downloader.py
@@ -4,13 +4,9 @@ from functools import partial
 import requests
 import hashlib
 import warnings
-import stdeb
-from stdeb.pypi_simple import PyPIClient
+from stdeb.pypi_simple import PyPIClient, USER_AGENT
 
 myprint = print
-
-USER_AGENT = 'pypi-install/%s ( https://github.com/astraw/stdeb )' % \
-    stdeb.__version__
 
 
 def find_tar_gz(package_name, pypi_url='https://pypi.org',

--- a/stdeb/pypi_simple.py
+++ b/stdeb/pypi_simple.py
@@ -1,6 +1,9 @@
 import re
 import requests
-from stdeb.downloader import USER_AGENT
+import stdeb
+
+USER_AGENT = 'pypi-install/%s ( https://github.com/astraw/stdeb )' % \
+    stdeb.__version__
 
 
 def normalize_package_name(package_name):


### PR DESCRIPTION
This was introduced in 0787a84 which shows you what comes of adding last minute unreviewed changes without having CI up.

This is a fixup after #201 which I will merge directly.