### PR TITLE
Use an available python2 binary name in debian templates.

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -1116,6 +1116,14 @@ class DebianInfo:
 
         if not (with_python2 or with_python3):
             raise RuntimeError('nothing to do - neither Python 2 or 3.')
+
+        if with_python2:
+            if shutil.which("python"):
+                self.python2_binname = "python"
+            elif shutil.which("python2"):
+                self.python2_binname = "python2"
+            else:
+                raise RuntimeError("Python 2 binary not found on path as either `python` or `python2`")
         sequencer_with = []
         if with_python2:
             sequencer_with.append('python2')
@@ -1650,7 +1658,7 @@ RULES_MAIN = """\
 %(binary_target_lines)s
 """
 
-RULES_OVERRIDE_CLEAN_TARGET_PY2 = "        python setup.py clean -a"
+RULES_OVERRIDE_CLEAN_TARGET_PY2 = "        %(python2_binname)s setup.py clean -a"
 RULES_OVERRIDE_CLEAN_TARGET_PY3 = "        python3 setup.py clean -a"
 RULES_OVERRIDE_CLEAN_TARGET = r"""
 override_dh_auto_clean:
@@ -1658,14 +1666,14 @@ override_dh_auto_clean:
         find . -name \*.pyc -exec rm {} \;
 """
 
-RULES_OVERRIDE_BUILD_TARGET_PY2 = "        python setup.py build --force"
+RULES_OVERRIDE_BUILD_TARGET_PY2 = "        %(python2_binname)s setup.py build --force"
 RULES_OVERRIDE_BUILD_TARGET_PY3 = "        python3 setup.py build --force"
 RULES_OVERRIDE_BUILD_TARGET = """
 override_dh_auto_build:
 %(rules_override_build_target_pythons)s
 """
 
-RULES_OVERRIDE_INSTALL_TARGET_PY2 = "        python setup.py install --force --root=debian/%(package)s --no-compile -O0 --install-layout=deb %(install_prefix)s %(no_python2_scripts_cli_args)s"  # noqa: E501
+RULES_OVERRIDE_INSTALL_TARGET_PY2 = "        %(python2_binname)s setup.py install --force --root=debian/%(package)s --no-compile -O0 --install-layout=deb %(install_prefix)s %(no_python2_scripts_cli_args)s"  # noqa: E501
 
 RULES_OVERRIDE_INSTALL_TARGET_PY3 = "        python3 setup.py install --force --root=debian/%(package3)s --no-compile -O0 --install-layout=deb %(install_prefix)s %(no_python3_scripts_cli_args)s"  # noqa: E501
 

--- a/test2and3.sh
+++ b/test2and3.sh
@@ -116,6 +116,11 @@ if [ "$DO_PY3" = true ]; then
       # test the "sdist_dsc" and "bdist_deb" commands
       ${PY3EXE} setup.py --command-packages stdeb.command sdist_dsc --with-python3=true --with-python2=false bdist_deb
       cd ../..
+
+      echo "using Python 3 to test 2 and 3 generation"
+      cd test_data/simple_pkg
+      ${PY3EXE} setup.py --command-packages stdeb.command sdist_dsc --with-python3=true --with-python2=true bdist_deb
+      cd ../..
     else
       echo "skipping Python >= 3.2 test"
     fi


### PR DESCRIPTION
Ubuntu Focal and Jammy install a `python2` binary with python-all-dev.
Rather than requiring that tests and downstream packages always install python-is-python2 (seemingly unavailable on jammy), check the current path for each binary and use the first one found, preferring `python` when it is available to maintain current behavior but using `python2` if it's the only option.

This unblocks testing python2 package generation with python3-stdeb in test-2and3.sh.

However, this case doesn't appear to be tested so I've added an additional case when testing python3.

Although I am planning to drop support for installing/running stdeb from python2 (#198) I am hoping to preserve, at least for a while, support for generating python2 packages using the python3 version of stdeb.
