### PR TITLE
Use setuptools and entry_points for setup.py subcommands.

### DIFF
--- a/build.earth
+++ b/build.earth
@@ -23,7 +23,7 @@ BUILD:
 		libpq-dev python3-all-dev
 
 	DO +SRC
-	RUN python3 setup.py --command-packages=stdeb.command bdist_deb
+	RUN python3 setup.py bdist_deb
 	RUN for f in deb_dist/*.deb; do echo; echo $f; dpkg --contents $f; done
 
 INSTALL:

--- a/build.earth
+++ b/build.earth
@@ -14,7 +14,7 @@ BUILD:
 	ENV DEBIAN_FRONTEND=noninteractive
 	RUN apt-get update; apt-get install -y \
 		# Build deps \
-		debhelper dh-python python3-all python3-pip python3-setuptools \
+		debhelper dh-python python3-all python3-pip python3-setuptools python3-venv \
 		# Install deps \
 		python3-requests apt-file \
 		# Pip install deps \
@@ -23,7 +23,10 @@ BUILD:
 		libpq-dev python3-all-dev
 
 	DO +SRC
-	RUN python3 setup.py bdist_deb
+	RUN python3 -m venv venv
+	RUN . venv/bin/activate && python3 -m pip install .
+	RUN . venv/bin/activate && python3 setup.py bdist_deb
+	RUN rm -r venv
 	RUN for f in deb_dist/*.deb; do echo; echo $f; dpkg --contents $f; done
 
 INSTALL:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
-from distutils.core import setup
+from setuptools import setup
 import codecs
 
 with codecs.open('README.rst', encoding='utf-8') as file:
     long_description = file.read()
-
 
 setup(
     name='stdeb',
@@ -17,6 +16,8 @@ setup(
     license='MIT',
     url='http://github.com/astraw/stdeb',
     packages=['stdeb', 'stdeb.command'],
+    entry_points={'distutils.commands': ["%(cmd)s = stdeb.command.%(cmd)s:%(cmd)s" % {'cmd': x}
+                                         for x in ('bdist_deb', 'debianize', 'install_deb', 'sdist_dsc', )], },
     scripts=[
         'scripts/py2dsc',
         'scripts/py2dsc-deb',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ setup(
     long_description=long_description,
     license='MIT',
     url='http://github.com/astraw/stdeb',
-    install_requires=['setuptools>=59'],
+    install_requires=[
+        'requests',
+        'setuptools>=59',
+    ],
     packages=['stdeb', 'stdeb.command'],
     entry_points={'distutils.commands': ["%(cmd)s = stdeb.command.%(cmd)s:%(cmd)s" % {'cmd': x}
                                          for x in ('bdist_deb', 'debianize', 'install_deb', 'sdist_dsc', )], },

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     long_description=long_description,
     license='MIT',
     url='http://github.com/astraw/stdeb',
+    install_requires=['setuptools'],
     packages=['stdeb', 'stdeb.command'],
     entry_points={'distutils.commands': ["%(cmd)s = stdeb.command.%(cmd)s:%(cmd)s" % {'cmd': x}
                                          for x in ('bdist_deb', 'debianize', 'install_deb', 'sdist_dsc', )], },

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=long_description,
     license='MIT',
     url='http://github.com/astraw/stdeb',
-    install_requires=['setuptools'],
+    install_requires=['setuptools>=59'],
     packages=['stdeb', 'stdeb.command'],
     entry_points={'distutils.commands': ["%(cmd)s = stdeb.command.%(cmd)s:%(cmd)s" % {'cmd': x}
                                          for x in ('bdist_deb', 'debianize', 'install_deb', 'sdist_dsc', )], },

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,3 +1,3 @@
 [stdeb]
 Depends: apt-file, dpkg-dev, python-pkg-resources, python-requests
-Depends3: apt-file, dpkg-dev, python3-pkg-resources, python3-requests, python3-setuptools
+Depends3: apt-file, dpkg-dev, python3-pkg-resources, python3-requests, python3-setuptools (>= 59)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,3 +1,3 @@
 [stdeb]
 Depends: apt-file, dpkg-dev, python-pkg-resources, python-requests
-Depends3: apt-file, dpkg-dev, python3-pkg-resources, python3-requests, python3 (<< 3.12) | python3-setuptools
+Depends3: apt-file, dpkg-dev, python3-pkg-resources, python3-requests, python3-setuptools

--- a/stdeb/cli_runner.py
+++ b/stdeb/cli_runner.py
@@ -116,8 +116,8 @@ def runit(cmd, usage):
     if cmd == 'bdist_deb':
         extra_args.append('bdist_deb')
 
-    args = [sys.executable, 'setup.py', '--command-packages', 'stdeb.command',
-            'sdist_dsc', '--dist-dir=%s' % abs_dist_dir,
+    args = [sys.executable, 'setup.py', 'sdist_dsc',
+            '--dist-dir=%s' % abs_dist_dir,
             '--use-premade-distfile=%s' % os.path.abspath(sdist_file)
             ] + extra_args
 

--- a/stdeb/command/bdist_deb.py
+++ b/stdeb/command/bdist_deb.py
@@ -1,7 +1,7 @@
 import os
 import stdeb.util as util
 
-from distutils.core import Command
+from setuptools import Command
 
 __all__ = ['bdist_deb']
 

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -2,8 +2,8 @@ import os
 import sys
 
 from stdeb import log
-from distutils.core import Command
-from distutils.errors import DistutilsModuleError
+from setuptools import Command
+from setuptools.errors import ModuleError
 
 from stdeb.util import DebianInfo, DH_DEFAULT_VERS, stdeb_cfg_options
 
@@ -135,7 +135,7 @@ class common_debian_package_command(Command):
         use_setuptools = True
         try:
             ei_cmd = self.distribution.get_command_obj('egg_info')
-        except DistutilsModuleError:
+        except ModuleError:
             use_setuptools = False
 
         config_fname = 'stdeb.cfg'

--- a/stdeb/command/debianize.py
+++ b/stdeb/command/debianize.py
@@ -1,4 +1,3 @@
-from distutils.core import Command  # noqa: F401
 from stdeb.command.common import common_debian_package_command
 
 from stdeb.util import build_dsc, stdeb_cmdline_opts, \


### PR DESCRIPTION
However, this requires setuptools (which was removed in 2009).

This is a rebase of #114 now that the upstream branch has been deleted.