### PR TITLE
Fix regression in 0.10.1 by adding a shim function.

### DIFF
--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -26,6 +26,12 @@ else:
     # matplotlib deletes link from os namespace, expected distutils workaround
     link_func = shutil.copyfile
 
+if hasattr(shutil, 'which'):
+    which = shutil.which
+else:
+    from stdeb.which import which
+
+
 __all__ = ['DebianInfo', 'build_dsc', 'expand_tarball', 'expand_zip',
            'stdeb_cmdline_opts', 'stdeb_cmd_bool_opts', 'recursive_hardlink',
            'apply_patch', 'repack_tarball_with_debianized_dirname',
@@ -1118,9 +1124,9 @@ class DebianInfo:
             raise RuntimeError('nothing to do - neither Python 2 or 3.')
 
         if with_python2:
-            if shutil.which("python"):
+            if which("python"):
                 self.python2_binname = "python"
-            elif shutil.which("python2"):
+            elif which("python2"):
                 self.python2_binname = "python2"
             else:
                 raise RuntimeError("Python 2 binary not found on path as either `python` or `python2`")

--- a/stdeb/which.py
+++ b/stdeb/which.py
@@ -1,0 +1,18 @@
+import os
+
+# Implementation inspired by shutil.which from Python 3.3+
+def which(program):
+    def _is_executable(path):
+        return os.path.isfile(path) and os.access(path, os.X_OK)
+
+    path, _name = os.path.split(program)
+    if path:
+        if _is_executable(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if _is_executable(exe_file):
+                return exe_file
+
+    return None


### PR DESCRIPTION
This regression was introduced in
https://github.com/astraw/stdeb/pull/203 and incorporated into the 0.10.1 release (which was not ever tagged and published).