### PR TITLE
Add news for off-master 0.10.2 release.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,14 @@ interpreter (and only the Python3 package installs scripts)::
 
 News
 ----
+ * 2025-07-31: **Version 0.10.2**. See the `download page
+   <https://pypi.python.org/pypi/stdeb/0.10.2>`__.
+   This is a bugfix release for 0.10.1 which fixes a regression.
+
+  * Bugfixes:
+
+    * Add a shim function for which on python2. (#215)
+      * Fixes a regression introduced in  #203.
 
  * 2024-11-14: **Version 0.10.1**. See the `download page
    <https://pypi.python.org/pypi/stdeb/0.10.1>`__.

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,5 +1,16 @@
 See the News section in the README for more details.
 
+Release 0.10.2
+==============
+
+Bugfix release addressing a regression in 0.10.1.
+
+Release 0.10.1
+==============
+
+This is the last planned release of stdeb which supports running stdeb scripts
+with Python 2.7.
+
 Release 0.10.0
 ==============
 


### PR DESCRIPTION
This release was made from a 0.10.x branch, created to support bugfixes for the Python2 support branch. Future releases on this branch are not anticipated unless I find another regression releasing my own packages.