### PR TITLE
Simplified and updated .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 build
 deb_dist
+__pycache__/
 *.pyc
-stdeb.egg-info/PKG-INFO
-stdeb.egg-info/SOURCES.txt
-stdeb.egg-info/dependency_links.txt
-stdeb.egg-info/entry_points.txt
-stdeb.egg-info/top_level.txt
+*.egg-info
 dist
 *~
 MANIFEST
+venv
+*.tar.gz
+.ruff_cache


### PR DESCRIPTION
## Description of contribution in a few bullet points
* Simplified `*.egg-info` ignores for brevity.
* Updated folder level ignores for `ruff` and `pycache`, as these still appear as empty folders (with ignored files) due to no top-level ignores.
* Included a `venv` ignore for working with virtual environments.
* Ignored the gzip file - `tar.gz`, when trying to build the package locally.

