### PR TITLE
Drop license classifier in favor of SPDX expression.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
## Description of contribution in a few bullet points
* Official Python packaging documentation now recommends using [SPDX expressions](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) instead of Trove's classifiers, and resolves the following warning:

   ```text
   dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
   !!

           ********************************************************************************
           Please consider removing the following classifiers in favor of a SPDX license expression:
   
           License :: OSI Approved :: MIT License
   
           See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
           ********************************************************************************
   !!
   ```
## Description of how this change was tested
   
* No warnings when invoking `python3 -m build`.
   

